### PR TITLE
Issues page - minor code optimizations

### DIFF
--- a/issues.js
+++ b/issues.js
@@ -197,14 +197,11 @@ function renderLanguages() {
     $("#issues_list").html(rendered_langs);
 }
 
-$(document).ready(function() {
-    var url = 'https://duckduckhack.com/open_issues/';
+var url = 'https://duckduckhack.com/open_issues/';
     
-    $.getJSON(url, function(data) {
-        renderLanguages();
-        groupIssuesByLanguage(data.items);
-    });
-
+$.getJSON(url, function(data) {
+    renderLanguages();
+    groupIssuesByLanguage(data.items);
 });
 
 //! moment.js

--- a/issues.js
+++ b/issues.js
@@ -197,10 +197,12 @@ function renderLanguages() {
     $("#issues_list").html(rendered_langs);
 }
 
-var url = 'https://duckduckhack.com/open_issues/';
     
+renderLanguages();
+
+var url = 'https://duckduckhack.com/open_issues/';
+
 $.getJSON(url, function(data) {
-    renderLanguages();
     groupIssuesByLanguage(data.items);
 });
 

--- a/src/js/issues.js
+++ b/src/js/issues.js
@@ -76,9 +76,11 @@ function renderLanguages() {
     $("#issues_list").html(rendered_langs);
 }
 
-var url = 'https://duckduckhack.com/open_issues/';
     
+renderLanguages();
+
+var url = 'https://duckduckhack.com/open_issues/';
+
 $.getJSON(url, function(data) {
-    renderLanguages();
     groupIssuesByLanguage(data.items);
 });

--- a/src/js/issues.js
+++ b/src/js/issues.js
@@ -76,12 +76,9 @@ function renderLanguages() {
     $("#issues_list").html(rendered_langs);
 }
 
-$(document).ready(function() {
-    var url = 'https://duckduckhack.com/open_issues/';
+var url = 'https://duckduckhack.com/open_issues/';
     
-    $.getJSON(url, function(data) {
-        renderLanguages();
-        groupIssuesByLanguage(data.items);
-    });
-
+$.getJSON(url, function(data) {
+    renderLanguages();
+    groupIssuesByLanguage(data.items);
 });


### PR DESCRIPTION
- Removed `$(document).ready()`
- Now loading the language containers outside of the GET request

Loading time improved slightly.
Before these changes:
<img width="2088" alt="screen shot 2016-11-22 at 3 24 27 pm" src="https://cloud.githubusercontent.com/assets/3652195/20542004/a1f1ffe2-b0cd-11e6-9ebf-cdc3dca5db89.png">


After:
<img width="2085" alt="screen shot 2016-11-22 at 3 16 57 pm" src="https://cloud.githubusercontent.com/assets/3652195/20542009/a6643306-b0cd-11e6-80cd-d723a2bcb7a8.png">
