### PR TITLE
Fix C# labeled issues breaking the page

### DIFF
--- a/issues.js
+++ b/issues.js
@@ -52,6 +52,15 @@ this["Handlebars"]["templates"]["lang_groups"] = Handlebars.template({"1":functi
 },"2":function(container,depth0,helpers,partials,data) {
     return "Cplusplus";
 },"4":function(container,depth0,helpers,partials,data) {
+    var stack1;
+
+  return ((stack1 = (helpers.eq || (depth0 && depth0.eq) || helpers.helperMissing).call(depth0 != null ? depth0 : {},depth0,"C#",{"name":"eq","hash":{},"fn":container.program(5, data, 0),"inverse":container.program(7, data, 0),"data":data})) != null ? stack1 : "");
+},"5":function(container,depth0,helpers,partials,data) {
+    var helper;
+
+  return "Csharp"
+    + container.escapeExpression(((helper = (helper = helpers.eq || (depth0 != null ? depth0.eq : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : {},{"name":"eq","hash":{},"data":data}) : helper)));
+},"7":function(container,depth0,helpers,partials,data) {
     return container.escapeExpression(container.lambda(depth0, depth0));
 },"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
     var stack1;
@@ -122,6 +131,7 @@ Handlebars.registerHelper('strip_label', function(label) {
 var langs = [
     "C",
     "C++",
+    "C#",
     "CSS",
     "Java",
     "JavaScript",
@@ -182,7 +192,13 @@ function groupIssuesByLanguage(issues) {
 // Append the give issue to the appropriate Language list
 function renderIssue(issue) {
     var rendered_issue = Handlebars.templates.issues(issue);
-    issue.lang = (issue.lang === "C++")? "Cplusplus" : issue.lang;
+    
+    if (issue.lang === "C++") {
+        issue.lang = "Cplusplus";
+    } else if (issue.lang === "C#") {
+        issue.lang = "Csharp";
+    }
+
     var $lang_group = $("#" + issue.lang);
     $lang_group.removeClass("hide");
     $lang_group.children("ul").append(rendered_issue);

--- a/src/js/issues.js
+++ b/src/js/issues.js
@@ -1,6 +1,7 @@
 var langs = [
     "C",
     "C++",
+    "C#",
     "CSS",
     "Java",
     "JavaScript",
@@ -61,7 +62,13 @@ function groupIssuesByLanguage(issues) {
 // Append the give issue to the appropriate Language list
 function renderIssue(issue) {
     var rendered_issue = Handlebars.templates.issues(issue);
-    issue.lang = (issue.lang === "C++")? "Cplusplus" : issue.lang;
+    
+    if (issue.lang === "C++") {
+        issue.lang = "Cplusplus";
+    } else if (issue.lang === "C#") {
+        issue.lang = "Csharp";
+    }
+
     var $lang_group = $("#" + issue.lang);
     $lang_group.removeClass("hide");
     $lang_group.children("ul").append(rendered_issue);

--- a/src/templates/handlebars_tmp
+++ b/src/templates/handlebars_tmp
@@ -52,6 +52,15 @@ this["Handlebars"]["templates"]["lang_groups"] = Handlebars.template({"1":functi
 },"2":function(container,depth0,helpers,partials,data) {
     return "Cplusplus";
 },"4":function(container,depth0,helpers,partials,data) {
+    var stack1;
+
+  return ((stack1 = (helpers.eq || (depth0 && depth0.eq) || helpers.helperMissing).call(depth0 != null ? depth0 : {},depth0,"C#",{"name":"eq","hash":{},"fn":container.program(5, data, 0),"inverse":container.program(7, data, 0),"data":data})) != null ? stack1 : "");
+},"5":function(container,depth0,helpers,partials,data) {
+    var helper;
+
+  return "Csharp"
+    + container.escapeExpression(((helper = (helper = helpers.eq || (depth0 != null ? depth0.eq : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : {},{"name":"eq","hash":{},"data":data}) : helper)));
+},"7":function(container,depth0,helpers,partials,data) {
     return container.escapeExpression(container.lambda(depth0, depth0));
 },"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
     var stack1;

--- a/src/templates/lang_groups.handlebars
+++ b/src/templates/lang_groups.handlebars
@@ -1,5 +1,5 @@
 {{#each languages}}
-<div id="{{#eq this 'C++'}}Cplusplus{{else}}{{this}}{{/eq}}" class="hide lang_group">
+<div id="{{#eq this 'C++'}}Cplusplus{{else}}{{#eq this 'C#'}}Csharp{{eq}}{{else}}{{this}}{{/eq}}{{/eq}}" class="hide lang_group">
   <h4 class="f3 black-70">{{this}}</h4>
   <ul class="list pl0 ml0 center ba b--black-10 br1 mb4 pb0 bg-black-05 pt0">
     <li class="issue--item h3 pv3 bb b--black-10">


### PR DESCRIPTION
So the hard truth is, I completely forgot to consider C# when creating this page, and that's why I didn't add a special case for it like I did with C++, to avoid having weird chars in the div ID.

This should fix the issue.