### PR TITLE
Remove Programming Mission Text

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,9 +92,8 @@
 							<i class="fa fa-check-circle"></i>
 							<h2 class="ddh__title">Get Started</h2>
 							<p>
-								The DuckDuckHack community is focused on improving search
-								<br/> results for the top 15 programming languages. Our goal is to have a high quality, relevant Instant Answer for
-								every search.
+								The DuckDuckHack community is focused on improving search results with Instant Answers.<br/>
+								Our goal is to have a high quality, relevant Instant Answer for every search.
 							</p>
 							<div class="ddh--help__link">
 								<i class="fa-arrow-circle-o-right fa"></i> <a href="issues.html">Choose a task</a>


### PR DESCRIPTION
Minor change to "Get Started" text that remove the Programming Mission text.

/cc @pjhampton 


