### PR TITLE
Fix DuckDuckHack URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Welcome to DuckDuckHack!
 
-This repo contains the static content used to build [DuckDuckHack.com](DuckDuckHack.com)
+This repo contains the static content used to build [DuckDuckHack.com](https://duckduckhack.com/)
 
 ## Setting up
 


### PR DESCRIPTION
The old URL will lead user to `https://github.com/duckduckgo/duckduckhack.com/blob/master/DuckDuckHack.com` since it's not an absolute URL.